### PR TITLE
added `dt` to tutorial movie vis

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -111,7 +111,7 @@ about swing completely back up.
 
 .. code:: python
 
-    visu = viz.Visualizer(results, pend, speed=1)
+    visu = viz.Visualizer(results, pend, dt = dt, speed=1)
 
 We can confirm this by creating a vizualizer using the ``Visualizer``
 class. We instantiate it with the same ``pend`` object, and the results


### PR DESCRIPTION
I received an error in the tutorial

```python
In [18]: visu = viz.Visualizer(results, pend, speed=1)                                                              
---------------------------------------------------------------------------                                         
TypeError                                 Traceback (most recent call last)                                         
Input In [18], in <cell line: 1>()                                                                                  
----> 1 visu = viz.Visualizer(results, pend, speed=1)                                                               
                                                                                                                    
TypeError: Visualizer.__init__() missing 1 required positional argument: 'dt'                                       
```

So I added the `dt  = dt` argument to the `Visualizer` argument in the tutorial